### PR TITLE
[FIX-FACEBOOK-SHOW] Add Conditional Rendering for Game Over and Not Started States in Flappy Bird

### DIFF
--- a/src/pages/game/flappybird/index.jsx
+++ b/src/pages/game/flappybird/index.jsx
@@ -153,13 +153,13 @@ const GameComponent = () => {
   },[gameOver])
   return (
     <div className="flex items-center justify-center h-screen relative">
-      <div className="absolute top-4 right-4">
+     {(!start ||gameOver) && <div className="absolute top-4 right-4">
         <Typography style={{alignItems: "center"}}>Want more turn?</Typography>
         <div>
           <ShareToFacebook game_id={id}/>
           <AskGameTurnBtn game_id={id} />
         </div>
-      </div>
+      </div>}
       {/* Canvas game */}
       {!gameOver && start ? (
         <canvas id="gameCanvas" />


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | No |

## Problem

- The user interface did not provide specific feedback or options when the Flappy Bird game was not started or was over.
- There was a need to enhance user engagement by offering sharing options and game turn prompts during these states.

## Solution

- Implemented conditional rendering to display a message and two components, `ShareToFacebook` and `AskGameTurnBtn`, when the game has not started or is over.
- Used the condition `(!start || gameOver)` to determine when to show this additional UI.

## Test results

_Add your screenshots or recording about testing_

## Other changes

- No other changes were made outside of the conditional rendering logic adjustment.

## Deploy Notes

There are no new dependencies, scripts, or environment variables introduced with this PR.